### PR TITLE
allow AdvertisementRepository.cs to search on title or description

### DIFF
--- a/Controllers/Advertisements/AdvertisementController.cs
+++ b/Controllers/Advertisements/AdvertisementController.cs
@@ -18,9 +18,9 @@ public class AdvertisementController : BaseController
     }
 
     [HttpGet]
-    public Task<List<Advertisement>> Index()
+    public Task<List<Advertisement>> Index([FromQuery(Name = "q")] string? searchParams)
     {
-        return _service.GetAll();
+        return _service.GetAll(searchParams);
     }
 
     [Authorize]

--- a/Respositories/Advertisements/AdvertisementRepository.cs
+++ b/Respositories/Advertisements/AdvertisementRepository.cs
@@ -49,9 +49,20 @@ public class AdvertisementRepository
         return advertisement;
     }
 
-    public async Task<List<Advertisement>> GetAll()
+    public async Task<List<Advertisement>> GetAll(string? searchParams)
     {
-        var advertisements = await _ctx.Advertisements.ToListAsync();
+        List<Advertisement> advertisements;
+        
+        if (searchParams != null)
+        {
+            advertisements = await _ctx.Advertisements.Where(ad =>
+                ad.Title.Contains(searchParams) || ad.Description.Contains(searchParams)).ToListAsync();
+        }
+        else
+        {
+            advertisements = await _ctx.Advertisements.ToListAsync();
+        }
+        
         foreach (var advertisement in advertisements)
         {
             await _ctx.Entry(advertisement).Reference(ad => ad.Category).LoadAsync();

--- a/Services/Advertisements/AdvertisementService.cs
+++ b/Services/Advertisements/AdvertisementService.cs
@@ -36,9 +36,9 @@ public class AdvertisementService
         return await _repository.Get(id);
     }
 
-    public async Task<List<Advertisement>> GetAll()
+    public async Task<List<Advertisement>> GetAll(string? searchParams)
     {
-        return await _repository.GetAll();
+        return await _repository.GetAll(searchParams);
     }
     
     public async Task<Advertisement> Update(Advertisement advertisement, Advertisement oldAdvertisement)


### PR DESCRIPTION
Allows the front-end to search for title and description by specifying `q` in the requests query string. For example: `http://localhost:3001/Advertisement?q=Nieuwe iphone` would only show results where either the title or the description contains the text **nieuwe iphone**